### PR TITLE
Add Support For Excluding Files From Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Path to your [compile_commands.json](https://clang.llvm.org/docs/JSONCompilation
 
 - **Required.**
 
+### `file-exclude-regex`
+
+Extended regular expression for files that will be excluded from check.
+
+- **Default:** `''`
+- **Optional.** Specify `''` to ignore.
+
 ### `checks`
 
 Comma-separated list of checks to enable/disable.
@@ -81,6 +88,7 @@ In your **GitHub Workflow:**
   with:
     version: '18'
     compile-commands-path: './path/to/compile_commands.json'
+    file-exclude-regex: '/build/'
     checks: 'cppcoreguidelines-*, modernize-*, -readability-identifier-length'
     warnings-as-errors: 'cppcoreguidelines-*'
     config-file: './path/to/.clang-tidy'

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
     type: string
     required: true
 
+  file-exclude-regex:
+    description: Regular expression for files that will be excluded from check
+    type: string
+    required: false
+    default: ''
+
   checks:
     description: Comma-separated list of checks to enable/disable
     type: string
@@ -61,6 +67,7 @@ runs:
       env:
         CLANG_TIDY_VERSION: "${{inputs.version}}"
         CLANG_TIDY_COMPILE_COMMANDS_PATH: "${{inputs.compile-commands-path}}"
+        CLANG_TIDY_FILE_EXCLUDE_REGEX: "${{inputs.file-exclude-regex}}"
         CLANG_TIDY_CHECKS: "${{inputs.checks}}"
         CLANG_TIDY_WARNINGS_AS_ERRORS: "${{inputs.warnings-as-errors}}"
         CLANG_TIDY_CONFIG_FILE: "${{inputs.config-file}}"

--- a/script/clang_tidy_check.sh
+++ b/script/clang_tidy_check.sh
@@ -53,8 +53,13 @@ print_delim
 while IFS= read -r FILE_METADATA; do
 	FILE_PATH=$(jq -r '.file' <<<"$FILE_METADATA")
 
-	printf "Checking file %s...\n" "$FILE_PATH"
+	if [ -n "$CLANG_TIDY_FILE_EXCLUDE_REGEX" ] && grep -q -E -- "$CLANG_TIDY_FILE_EXCLUDE_REGEX" <<<"$FILE_PATH"; then
+		printf "Skipping file %s\n" "$FILE_PATH"
+		print_delim
+		continue
+	fi
 
+	printf "Checking file %s...\n" "$FILE_PATH"
 	if ! clang-tidy-"$CLANG_TIDY_VERSION" "${CLANG_TIDY_ARGS[@]}" \
 		"$FILE_PATH" 2>&1; then
 		CHECK_FAIL="true"


### PR DESCRIPTION
- Add new file-exclude-regex argument
- Files matching this regex will be excluded from check
- Argument must be a valid extended regular expression
- Add usage instructions to README.md