### PR TITLE
Fix clang-tidy-check Action Argument Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,44 @@ Path to your [compile_commands.json](https://clang.llvm.org/docs/JSONCompilation
 
 Extended regular expression for files that will be excluded from check.
 
-- **Default:** `''`
-- **Optional.** Specify `''` to ignore.
+- **Default:** `'__UNSET__'`
+- **Optional.**
+- If set to `'__UNSET__'`, no files will be excluded
 
 ### `checks`
 
 Comma-separated list of checks to enable/disable.
 
 - Same as **clang-tidy** `--checks=`.
-- **Default:** `''`
-- **Optional.** Specify `''` to ignore.
+- **Default:** `'__UNSET__'`
+- **Optional.**
+- If set to `'__UNSET__'`, option will be discarded
 
 ### `warnings-as-errors`
 
 Comma-separated list of warnings that will be treated as errors.
 
 - Same as **clang-tidy** `--warnings-as-errors=`.
-- **Default:** `'*'`
-- **Optional.** Specify `''` to ignore.
+- **Default:** `'__UNSET__'`
+- **Optional.**
+- If set to `'__UNSET__'`, option will be discarded
 
 ### `config-file`
 
 Path to custom `.clang-tidy` config file.
 
 - Same as **clang-tidy** `--config-file=`.
-- **Default:** `''`
-- **Optional.** Specify `''` to ignore.
+- **Default:** `'__UNSET__'`
+- **Optional.**
+- If set to `'__UNSET__'`, option will be discarded
 
 ### `extra-args`
 
 Any additional **clang-tidy** arguments.
 
-- **Default:** `''`
-- **Optional.** Specify `''` to ignore.
+- **Default:** `'__UNSET__'`
+- **Optional.**
+- If set to `'__UNSET__'`, option will be discarded
 
 ## Output
 

--- a/action.yml
+++ b/action.yml
@@ -18,31 +18,31 @@ inputs:
     description: Regular expression for files that will be excluded from check
     type: string
     required: false
-    default: ''
+    default: '__UNSET__'
 
   checks:
     description: Comma-separated list of checks to enable/disable
     type: string
     required: false
-    default: ''
+    default: '__UNSET__'
 
   warnings-as-errors:
     description: Comma-separated list of warnings that will be treated as errors
     type: string
     required: false
-    default: '*'
+    default: '__UNSET__'
 
   config-file:
     description: Path to custom .clang-tidy config file
     type: string
     required: false
-    default: ''
+    default: '__UNSET__'
 
   extra-args:
     description: Additional clang-tidy arguments
     type: string
     required: false
-    default: ''
+    default: '__UNSET__'
 
 runs:
   using: "composite"

--- a/script/clang_tidy_check.sh
+++ b/script/clang_tidy_check.sh
@@ -23,19 +23,21 @@ fi
 CLANG_TIDY_ARGS=()
 CLANG_TIDY_ARGS+=("-p=$CLANG_TIDY_COMPILE_COMMANDS_PATH")
 
-if [ -n "$CLANG_TIDY_CHECKS" ]; then
+UNSET_VALUE='__UNSET__'
+
+if [ "$CLANG_TIDY_CHECKS" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--checks=$CLANG_TIDY_CHECKS")
 fi
 
-if [ -n "$CLANG_TIDY_WARNINGS_AS_ERRORS" ]; then
+if [ "$CLANG_TIDY_WARNINGS_AS_ERRORS" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--warnings-as-errors=$CLANG_TIDY_WARNINGS_AS_ERRORS")
 fi
 
-if [ -n "$CLANG_TIDY_CONFIG_FILE" ]; then
+if [ "$CLANG_TIDY_CONFIG_FILE" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--config-file=$CLANG_TIDY_CONFIG_FILE")
 fi
 
-if [ -n "$CLANG_TIDY_EXTRA_ARGS" ]; then
+if [ "$CLANG_TIDY_EXTRA_ARGS" != "$UNSET_VALUE" ]; then
 	read -ra CLANG_TIDY_EXTRA_ARGS_ARRAY <<<"$CLANG_TIDY_EXTRA_ARGS"
 	CLANG_TIDY_ARGS+=("${CLANG_TIDY_EXTRA_ARGS_ARRAY[@]}")
 fi
@@ -53,7 +55,7 @@ print_delim
 while IFS= read -r FILE_METADATA; do
 	FILE_PATH=$(jq -r '.file' <<<"$FILE_METADATA")
 
-	if [ -n "$CLANG_TIDY_FILE_EXCLUDE_REGEX" ] && grep -q -E -- "$CLANG_TIDY_FILE_EXCLUDE_REGEX" <<<"$FILE_PATH"; then
+	if [ "$CLANG_TIDY_FILE_EXCLUDE_REGEX" != "$UNSET_VALUE" ] && grep -q -E -- "$CLANG_TIDY_FILE_EXCLUDE_REGEX" <<<"$FILE_PATH"; then
 		printf "Skipping file %s\n" "$FILE_PATH"
 		print_delim
 		continue


### PR DESCRIPTION
- Distinguish unset arguments vs arguments set to ""
- Use __UNSET__ sentinel for unset arguments
- Add info about new __UNSET__ argument values to README.md