### PR TITLE
Add Support For Providing Config Via String In YAML/JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Comma-separated list of warnings that will be treated as errors.
 - **Optional.**
 - If set to `'__UNSET__'`, option will be discarded
 
+### `config`
+
+A string specifying configuration in YAML/JSON format
+
+- Same as **clang-tidy** `--config=`.
+- **Default:** `'__UNSET__'`
+- **Optional.**
+- If set to `'__UNSET__'`, option will be discarded
+
 ### `config-file`
 
 Path to custom `.clang-tidy` config file.
@@ -96,6 +105,7 @@ In your **GitHub Workflow:**
     file-exclude-regex: '/build/'
     checks: 'cppcoreguidelines-*, modernize-*, -readability-identifier-length'
     warnings-as-errors: 'cppcoreguidelines-*'
+    config: '__UNSET__'
     config-file: './path/to/.clang-tidy'
     extra-args: '--quiet'
 ```

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,12 @@ inputs:
     required: false
     default: '__UNSET__'
 
+  config:
+    description: Configuration in a YAML/JSON format
+    type: string
+    required: false
+    default: '__UNSET__'
+
   config-file:
     description: Path to custom .clang-tidy config file
     type: string
@@ -70,6 +76,7 @@ runs:
         CLANG_TIDY_FILE_EXCLUDE_REGEX: "${{inputs.file-exclude-regex}}"
         CLANG_TIDY_CHECKS: "${{inputs.checks}}"
         CLANG_TIDY_WARNINGS_AS_ERRORS: "${{inputs.warnings-as-errors}}"
+        CLANG_TIDY_CONFIG: "${{inputs.config}}"
         CLANG_TIDY_CONFIG_FILE: "${{inputs.config-file}}"
         CLANG_TIDY_EXTRA_ARGS: "${{inputs.extra-args}}"
 

--- a/script/clang_tidy_check.sh
+++ b/script/clang_tidy_check.sh
@@ -33,6 +33,10 @@ if [ "$CLANG_TIDY_WARNINGS_AS_ERRORS" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--warnings-as-errors=$CLANG_TIDY_WARNINGS_AS_ERRORS")
 fi
 
+if [ "$CLANG_TIDY_CONFIG" != "$UNSET_VALUE" ]; then
+	CLANG_TIDY_ARGS+=("--config=$CLANG_TIDY_CONFIG")
+fi
+
 if [ "$CLANG_TIDY_CONFIG_FILE" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--config-file=$CLANG_TIDY_CONFIG_FILE")
 fi


### PR DESCRIPTION
- Add clang-tidy-check action argument: config
- Same as clang-tidy --config=
- Add info about argument to README.md 