### PR TITLE
Fix clang-tidy-check Version Issue In README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In your **GitHub Workflow:**
 
 ```yml
 - name: Run clang-tidy-check
-  uses: T-im4i-k/clang-tidy-check@v1
+  uses: T-im4i-k/clang-tidy-check@v2
   with:
     version: '18'
     compile-commands-path: './path/to/compile_commands.json'
@@ -116,7 +116,7 @@ In your **GitHub Workflow:**
 
 ```yml
 - name: Run clang-tidy check
-  uses: T-im4i-k/clang-tidy-check@v1
+  uses: T-im4i-k/clang-tidy-check@v2
   with:
     compile-commands-path: './path/to/compile_commands.json'
 ```


### PR DESCRIPTION
- Update action version used in examples: .../clang-tidy-check@v1 -> .../clang-tidy-check@v2