### PR TITLE
Add header-filter Argument To clang-tidy-check Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ option.
 
 If set to `'__UNSET__'`, option will not be passed to **clang-tidy**.
 
+### `header-filter`: \<string\> (optional)
+
+Extended regular expression to include specific header files in the check. Uses the same format as **clang-tidy**
+`--header-filter=` option.
+
+- **Default:** `'__UNSET__'`
+- **Example:** `'.*'`, `'/include/'`, `''`
+
+If set to `'__UNSET__'`, option will not be passed to **clang-tidy**.
+
 ### `config`: \<string\> (optional)
 
 Inline configuration in YAML/JSON format. Uses the same format as **clang-tidy** `--config=` option.
@@ -77,7 +87,8 @@ If set to `'__UNSET__'`, option will not be passed to **clang-tidy**.
 
 ### `config-file`: \<string\> (optional)
 
-Path to a `.clang-tidy` file or custom configuration file. Uses the same format as **clang-tidy** `--config-file=` option.
+Path to a `.clang-tidy` file or custom configuration file. Uses the same format as **clang-tidy** `--config-file=`
+option.
 
 - **Default:** `'__UNSET__'`
 - **Example:** `'./.clang-tidy'`, `'./config/my-clang-tidy-config'`
@@ -116,6 +127,7 @@ In your **GitHub Workflow:**
     file-exclude-regex: '/build/|/third_party/'
     checks: 'cppcoreguidelines-*, modernize-*, -readability-identifier-length'
     warnings-as-errors: 'cppcoreguidelines-*'
+    header-filter: '.*'
     config-file: './.clang-tidy'
     extra-args: '--quiet'
 ```

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,12 @@ inputs:
     required: false
     default: '__UNSET__'
 
+  header-filter:
+    description: Extended regular expression to include specific header files in the check.
+    type: string
+    required: false
+    default: '__UNSET__'
+
   config:
     description: Inline configuration in YAML/JSON format.
     type: string
@@ -86,6 +92,7 @@ runs:
         CLANG_TIDY_FILE_EXCLUDE_REGEX: "${{inputs.file-exclude-regex}}"
         CLANG_TIDY_CHECKS: "${{inputs.checks}}"
         CLANG_TIDY_WARNINGS_AS_ERRORS: "${{inputs.warnings-as-errors}}"
+        CLANG_TIDY_HEADER_FILTER: "${{inputs.header-filter}}"
         CLANG_TIDY_CONFIG: "${{inputs.config}}"
         CLANG_TIDY_CONFIG_FILE: "${{inputs.config-file}}"
         CLANG_TIDY_EXTRA_ARGS: "${{inputs.extra-args}}"

--- a/script/clang_tidy_check.sh
+++ b/script/clang_tidy_check.sh
@@ -34,6 +34,10 @@ if [ "$CLANG_TIDY_WARNINGS_AS_ERRORS" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--warnings-as-errors=$CLANG_TIDY_WARNINGS_AS_ERRORS")
 fi
 
+if [ "$CLANG_TIDY_HEADER_FILTER" != "$UNSET_VALUE" ]; then
+	CLANG_TIDY_ARGS+=("--header-filter=$CLANG_TIDY_HEADER_FILTER")
+fi
+
 if [ "$CLANG_TIDY_CONFIG" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--config=$CLANG_TIDY_CONFIG")
 fi


### PR DESCRIPTION
- Describes header files that should be checked by clang-tidy
- Same as clang-tidy --header-filter=