### PR TITLE
Add format-style Argument For clang-tidy-check Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ If set to `'__UNSET__'`, option will not be passed to **clang-tidy**.
 
 This argument overrides the 'HeaderFilterRegex' option in config, if any.
 
+### `format-style`: \<string\> (optional)
+
+Specifies the code formatting style to apply around proposed fixes. Uses the same format as **clang-tidy**
+`--format-style=` option.
+
+- **Default:** `'__UNSET__'`
+- **Example:** `'file'`, `'llvm'`, `'none'`
+
+If set to `'__UNSET__'`, option will not be passed to **clang-tidy**.
+
+This argument overrides the 'FormatStyle' option in config, if any.
+
 ### `config`: \<string\> (optional)
 
 Inline configuration in YAML/JSON format. Uses the same format as **clang-tidy** `--config=` option.
@@ -142,6 +154,7 @@ In your **GitHub Workflow:**
     checks: 'cppcoreguidelines-*, modernize-*, -readability-identifier-length'
     warnings-as-errors: 'cppcoreguidelines-*'
     header-filter: '.*'
+    format-style: 'file'
     config-file: './.clang-tidy'
     extra-args: '--quiet'
 ```

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,12 @@ inputs:
     required: false
     default: '__UNSET__'
 
+  format-style:
+    description: Specifies the code formatting style to apply around proposed fixes.
+    type: string
+    required: false
+    default: '__UNSET__'
+
   config:
     description: Inline configuration in YAML/JSON format.
     type: string
@@ -97,6 +103,7 @@ runs:
         CLANG_TIDY_CHECKS: "${{inputs.checks}}"
         CLANG_TIDY_WARNINGS_AS_ERRORS: "${{inputs.warnings-as-errors}}"
         CLANG_TIDY_HEADER_FILTER: "${{inputs.header-filter}}"
+        CLANG_TIDY_FORMAT_STYLE: "${{inputs.format-style}}"
         CLANG_TIDY_CONFIG: "${{inputs.config}}"
         CLANG_TIDY_CONFIG_FILE: "${{inputs.config-file}}"
         CLANG_TIDY_EXTRA_ARGS: "${{inputs.extra-args}}"

--- a/script/clang_tidy_check.sh
+++ b/script/clang_tidy_check.sh
@@ -41,6 +41,10 @@ if [ "$CLANG_TIDY_HEADER_FILTER" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--header-filter=$CLANG_TIDY_HEADER_FILTER")
 fi
 
+if [ "$CLANG_TIDY_FORMAT_STYLE" != "$UNSET_VALUE" ]; then
+	CLANG_TIDY_ARGS+=("--format-style=$CLANG_TIDY_FORMAT_STYLE")
+fi
+
 if [ "$CLANG_TIDY_CONFIG" != "$UNSET_VALUE" ]; then
 	CLANG_TIDY_ARGS+=("--config=$CLANG_TIDY_CONFIG")
 fi


### PR DESCRIPTION
- Specifies formatting style to apply around fixes suggested by clang-tidy
- Same as clang-tidy --format-style= option